### PR TITLE
README.mdに記載されたDockerの実行コマンドがインタラクティブモードなため、バックグラウンドモードで実行するようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ```bash
 docker build -t jet_black_pomeranian ./
-docker run -it --rm jet_black_pomeranian
+docker run -d --rm jet_black_pomeranian
 ```
 
 ## Python3がインストール済みのLinux環境で実行する場合


### PR DESCRIPTION
Fixes #30 実際動かしてるコマンドはすでに-dでバックグラウンドになっているが、readmeを変え忘れていたため修正しました。